### PR TITLE
fix issue of list hiding behind audio player in mobile view

### DIFF
--- a/components/archive-list.js
+++ b/components/archive-list.js
@@ -102,7 +102,7 @@ const ArchiveList = (props) => {
                 </div>
                 <style jsx>{`
                     .archive-container {
-                        margin-bottom: 50px;
+                        margin-bottom: 86px;
 
                     }
                     .center {


### PR DESCRIPTION
https://tree.taiga.io/project/marciaga-kffp-apps/us/100?kanban-status=1030171

this is to fix the issue where the schedule items hide behind the audio player in mobile view.

screenshot of issue from production: https://drive.google.com/open?id=1AByEVS-NXL18od0BH9TcJRP3YU5WwlWa

height of audio player is 86px in chrome on mac.